### PR TITLE
add unique clinic id field to clinic staff table

### DIFF
--- a/backend/src/main/java/com/is442/backend/controller/AuthController.java
+++ b/backend/src/main/java/com/is442/backend/controller/AuthController.java
@@ -1,11 +1,18 @@
 package com.is442.backend.controller;
 
-import com.is442.backend.model.*;
-import com.is442.backend.service.*;
-import com.is442.backend.dto.*;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.*;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.CrossOrigin;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.is442.backend.dto.SignupRequest;
+import com.is442.backend.model.ClinicStaff;
+import com.is442.backend.model.Patient;
+import com.is442.backend.model.SystemAdministrator;
+import com.is442.backend.service.UserService;
 
 @RestController
 @RequestMapping("/api/auth")
@@ -40,11 +47,12 @@ public class AuthController {
                     System.out.print(dto.getClinicName());
                     System.out.print(dto.getPosition());
                     if (dto.getClinicName() == null || dto.getClinicName().isEmpty() ||
+                            dto.getClinicId() == null || dto.getClinicId().isEmpty() ||
                             dto.getPosition() == null || dto.getPosition().isEmpty()) {
                         // Return error response if any value is missing
                         return ResponseEntity
                                 .badRequest()
-                                .body("Clinic name and position must be provided for staff registration");
+                                .body("Clinic name, clinic id and position must be provided for staff registration");
                     }
                     ClinicStaff staff = new ClinicStaff();
                     staff.setSupabaseUserId(dto.getSupabaseUserId());
@@ -55,6 +63,7 @@ public class AuthController {
                     staff.setStatus("ACTIVE");
 
                     staff.setClinicName(dto.getClinicName());
+                    staff.setClinicId(dto.getClinicId());
                     staff.setPosition(dto.getPosition());
                     return ResponseEntity.ok(userService.registerUser(staff));
                 }

--- a/backend/src/main/java/com/is442/backend/dto/SignupRequest.java
+++ b/backend/src/main/java/com/is442/backend/dto/SignupRequest.java
@@ -13,6 +13,7 @@ public class SignupRequest {
     private String dateOfBirth;
     private String gender;
     private String clinicName;
+    private String clinicId; // new field
     private String position;
 
     // Getters and Setters
@@ -88,6 +89,10 @@ public class SignupRequest {
     public void setClinicName(String clinicName) {
         this.clinicName = clinicName;
     }
+
+    public String getClinicId() { return clinicId; }
+
+    public void setClinicId(String clinicId) { this.clinicId = clinicId; }
 
     public String getPosition() {
         return position;

--- a/backend/src/main/java/com/is442/backend/model/ClinicStaff.java
+++ b/backend/src/main/java/com/is442/backend/model/ClinicStaff.java
@@ -1,9 +1,10 @@
 package com.is442.backend.model;
+import java.util.UUID;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.PrimaryKeyJoinColumn;
 import jakarta.persistence.Table;
-import java.util.UUID;
 
 
 @Entity
@@ -14,6 +15,9 @@ public class ClinicStaff extends User {
     @Column(name = "clinic_name")
     private String clinicName;
 
+    @Column(name = "clinic_id")
+    private String clinicId; // new column for stable reference
+
     @Column(name = "position")
     private String position; 
 
@@ -22,9 +26,10 @@ public class ClinicStaff extends User {
     }
 
     public ClinicStaff(UUID supabaseUserId, String email, String firstName, String lastName, String role, String status,
-                       String clinicName, String position) {
+                       String clinicName, String clinicId, String position) {
         super(supabaseUserId, email, firstName, lastName, role, status);
         this.clinicName = clinicName;
+        this.clinicId = clinicId;
         this.position = position;
     }
 
@@ -36,6 +41,10 @@ public class ClinicStaff extends User {
     public void setClinicName(String clinicName) {
         this.clinicName = clinicName;
     }
+
+    public String getClinicId() { return clinicId; }
+
+    public void setClinicId(String clinicId) { this.clinicId = clinicId; }
 
     public String getPosition() {
         return position;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -20,13 +20,12 @@ function App() {
           <RoleProtectedRoute role={["ROLE_ADMIN"]}>
             <SignUpPage />
           </RoleProtectedRoute>} />
+          
         <Route path="/viewappointment" element={
           <RoleProtectedRoute role={["ROLE_STAFF"]}>
             <StaffDashboard />
           </RoleProtectedRoute>
         } />
-
-      
 
         <Route
           path="/dashboard"

--- a/frontend/src/pages/StaffDashboard.tsx
+++ b/frontend/src/pages/StaffDashboard.tsx
@@ -91,8 +91,6 @@ export default function StaffDashboard() {
 
   const baseURL = import.meta.env.VITE_API_BASE_URL;
 
-  // Queue management state
-  // Legacy local queue placeholders (now unused after backend/SSE integration) removed
 
   // Get staff's clinic from user metadata
   const staffClinicId = user?.user_metadata?.clinicId


### PR DESCRIPTION
## Summary by Sourcery

Introduce a stable clinicId across backend models, DTOs, and the frontend sign-up flow, improve API configuration, and clean up outdated role and code paths

New Features:
- Add unique clinicId field to the ClinicStaff entity, SignupRequest DTO, and sign-up API payload
- Enable clinic selection by ID in the sign-up UI with combined “Name (ID)” labels

Enhancements:
- Externalize API base URL via VITE_API_BASE_URL and add fetch error handling in clinic loading
- Remove the deprecated ROLE_DOCTOR option and strip legacy unused code in StaffDashboard