### PR TITLE
commented out mock time that was used for testing

### DIFF
--- a/frontend/src/pages/PatientDashboard.tsx
+++ b/frontend/src/pages/PatientDashboard.tsx
@@ -91,8 +91,8 @@ export default function PatientDashboard() {
   const { toast } = useToast()
 
   //this is a fake test date to test my function
-  const currentNow = () => new Date(2025, 11, 11, 8, 0, 0)
-  // const currentNow = () => new Date()
+  // const currentNow = () => new Date(2025, 11, 11, 8, 0, 0)
+  const currentNow = () => new Date()
 
   // --- normalization helpers ---
   const toDateString = (booking_date: any): string => {

--- a/frontend/src/pages/StaffDashboard.tsx
+++ b/frontend/src/pages/StaffDashboard.tsx
@@ -103,6 +103,7 @@ export default function StaffDashboard() {
   const [staffClinicName, setStaffClinicName] = useState<string | undefined>(user?.user_metadata?.clinicName)
   const staffPosition = user?.user_metadata.position
 
+  console.log(staffPosition)
   useEffect(() => {
     const supabaseId = user?.id
     if (!supabaseId) return


### PR DESCRIPTION
## Summary by Sourcery

Re-enable the real current date in the PatientDashboard and add a debug console.log for staffPosition in the StaffDashboard

Enhancements:
- Restore real-time date functionality by commenting out the mock time in PatientDashboard
- Add console logging for staffPosition in StaffDashboard to aid debugging