### PR TITLE
websocket between different staff roles

### DIFF
--- a/backend/src/main/java/com/is442/backend/service/AppointmentService.java
+++ b/backend/src/main/java/com/is442/backend/service/AppointmentService.java
@@ -340,6 +340,18 @@ public class AppointmentService {
 
         appointment.setStatus(status);
         Appointment updated = appointmentRepository.save(appointment);
+        // Broadcast status change so staff dashboards can update in real-time
+        try {
+            messagingTemplate.convertAndSend("/topic/appointments/status", java.util.Map.of(
+                    "appointmentId", updated.getAppointmentId().toString(),
+                    "status", updated.getStatus(),
+                    "clinicId", updated.getClinicId(),
+                    "patientId", updated.getPatientId(),
+                    "doctorId", updated.getDoctorId()
+            ));
+        } catch (Exception e) {
+            logger.warn("Failed to publish appointment status update: {}", e.getMessage());
+        }
         return new AppointmentResponse(updated);
     }
 
@@ -507,6 +519,18 @@ public class AppointmentService {
             entityManager.flush();
             logger.info("Successfully created walk-in appointment: appointmentId={}, status=CHECKED-IN",
                     appointmentId);
+            // Broadcast new walk-in as CHECKED-IN so dashboards update
+            try {
+                messagingTemplate.convertAndSend("/topic/appointments/status", java.util.Map.of(
+                        "appointmentId", appointmentId.toString(),
+                        "status", "CHECKED-IN",
+                        "clinicId", clinicId,
+                        "patientId", patientId,
+                        "doctorId", doctorId
+                ));
+            } catch (Exception e2) {
+                logger.warn("Failed to publish walk-in status: {}", e2.getMessage());
+            }
         } catch (Exception e) {
             // Check if it's a duplicate key error (appointment was created in another
             // transaction)
@@ -544,6 +568,18 @@ public class AppointmentService {
             appointmentRepository.save(appointment);
 
             logger.info("Successfully updated appointment status to CHECKED-IN: appointmentId={}", appointmentId);
+            // Broadcast checked-in status to listeners
+            try {
+                messagingTemplate.convertAndSend("/topic/appointments/status", java.util.Map.of(
+                        "appointmentId", appointment.getAppointmentId().toString(),
+                        "status", appointment.getStatus(),
+                        "clinicId", appointment.getClinicId(),
+                        "patientId", appointment.getPatientId(),
+                        "doctorId", appointment.getDoctorId()
+                ));
+            } catch (Exception e2) {
+                logger.warn("Failed to publish checked-in update: {}", e2.getMessage());
+            }
         } catch (Exception e) {
             logger.error("Error updating appointment status to CHECKED-IN: appointmentId={}, error={}",
                     appointmentId, e.getMessage(), e);

--- a/frontend/src/lib/socket.ts
+++ b/frontend/src/lib/socket.ts
@@ -100,6 +100,82 @@ export function subscribeToSlots(handler: (payload: any) => void) {
   };
 }
 
+export function subscribeToAppointmentStatus(handler: (payload: any) => void) {
+  const destination = '/topic/appointments/status';
+  if (!client) connectSocket();
+
+  if (client && (client as any).connected) {
+    try {
+      const sub = client.subscribe(destination, (message) => {
+        try {
+          const body = JSON.parse(message.body);
+          handler(body);
+        } catch (e) {
+          console.error('Failed to parse appointment status update', e);
+        }
+      });
+      return {
+        unsubscribe: () => {
+          try { sub.unsubscribe(); } catch (e) {}
+        },
+      };
+    } catch (e) {
+      console.error('Failed to subscribe immediately', e);
+    }
+  }
+
+  const pending: { destination: string; handler: (payload: any) => void; sub?: any } = { destination, handler, sub: undefined };
+  pendingSubs.push(pending);
+
+  return {
+    unsubscribe: () => {
+      if (pending.sub) {
+        try { pending.sub.unsubscribe(); } catch (e) {}
+      } else {
+        pendingSubs = pendingSubs.filter((p) => p !== pending);
+      }
+    },
+  };
+}
+
+export function subscribeToTreatmentNotes(handler: (payload: any) => void) {
+  const destination = '/topic/appointments/treatment-notes';
+  if (!client) connectSocket();
+
+  if (client && (client as any).connected) {
+    try {
+      const sub = client.subscribe(destination, (message) => {
+        try {
+          const body = JSON.parse(message.body);
+          handler(body);
+        } catch (e) {
+          console.error('Failed to parse treatment note update', e);
+        }
+      });
+      return {
+        unsubscribe: () => {
+          try { sub.unsubscribe(); } catch (e) {}
+        },
+      };
+    } catch (e) {
+      console.error('Failed to subscribe immediately', e);
+    }
+  }
+
+  const pending: { destination: string; handler: (payload: any) => void; sub?: any } = { destination, handler, sub: undefined };
+  pendingSubs.push(pending);
+
+  return {
+    unsubscribe: () => {
+      if (pending.sub) {
+        try { pending.sub.unsubscribe(); } catch (e) {}
+      } else {
+        pendingSubs = pendingSubs.filter((p) => p !== pending);
+      }
+    },
+  };
+}
+
 export function disconnectSocket() {
   if (client) {
     try { client.deactivate(); } catch (e) {}

--- a/frontend/src/pages/StaffDashboard.tsx
+++ b/frontend/src/pages/StaffDashboard.tsx
@@ -26,7 +26,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Textarea } from "@/components/ui/textarea"
 import { useToast } from "@/components/ui/use-toast"
 import { useAuth } from "@/context/auth-context"
-import { connectSocket, disconnectSocket, subscribeToSlots } from "@/lib/socket"
+import { connectSocket, disconnectSocket, subscribeToAppointmentStatus, subscribeToSlots, subscribeToTreatmentNotes } from "@/lib/socket"
 import { cn } from "@/lib/utils"
 import { AlertTriangle, Calendar as CalendarIcon, CheckCircle, CheckCircle2, Clock, FileText, User, UserPlus } from "lucide-react"
 import { useEffect, useState } from "react"
@@ -103,7 +103,8 @@ export default function StaffDashboard() {
   const [staffClinicName, setStaffClinicName] = useState<string | undefined>(user?.user_metadata?.clinicName)
   const staffPosition = user?.user_metadata.position
 
-  console.log(staffPosition)
+  console.log(staffClinicId);
+  
   useEffect(() => {
     const supabaseId = user?.id
     if (!supabaseId) return
@@ -139,6 +140,7 @@ export default function StaffDashboard() {
           clinic_id: typeof appt.clinic_id === "string" ? appt.clinic_id.trim() : appt.clinic_id,
           clinic_name:
             typeof appt.clinic_name === "string" ? appt.clinic_name.trim() : appt.clinic_name,
+          status: normalizeStatus(appt.status),
         }))
 
         const filteredData = normalized.filter(appt => {
@@ -159,7 +161,9 @@ export default function StaffDashboard() {
           staffClinicName,
         })
 
-        setAppointments(filteredData)
+        // Sort by booking date and start time ascending (earliest first)
+        const sorted = [...filteredData].sort((a, b) => getApptSortKey(a) - getApptSortKey(b))
+        setAppointments(sorted)
       })
       .catch(err => {
         console.error("Error fetching appointments:", err)
@@ -394,6 +398,9 @@ export default function StaffDashboard() {
 
   // Filter Function
   const filteredAppointments = appointments.filter(appt => {
+    // Restrict upcoming to SCHEDULED and CHECKED-IN only
+    const norm = normalizeStatus(appt.status)
+    const statusMatch = norm === "SCHEDULED" || norm === "CHECKED-IN"
     const doctorMatch = filterDoctor === "All" || appt.doctor_id === filterDoctor
     const targetDate = dateToYMD(filterDate)
     const dateMatch = !targetDate || toIsoDate(appt.booking_date) === targetDate
@@ -403,8 +410,11 @@ export default function StaffDashboard() {
         .toLowerCase()
         .includes(filterPatientName.toLowerCase())
 
-    return doctorMatch && dateMatch && nameMatch
+    return statusMatch && doctorMatch && dateMatch && nameMatch
   })
+
+  // Sort filtered list to ensure display is ordered even after in-memory mutations
+  filteredAppointments.sort((a, b) => getApptSortKey(a) - getApptSortKey(b))
 
   // Apply the same filters to completed appointments
   const filteredCompletedAppointments = completedAppointments.filter(appt => {
@@ -416,6 +426,17 @@ export default function StaffDashboard() {
       (appt.patient_name || "").toLowerCase().includes(filterPatientName.toLowerCase())
     return doctorMatch && dateMatch && nameMatch
   })
+  // Optional: keep completed sorted by date/time descending (most recent first)
+  filteredCompletedAppointments.sort((a, b) => getApptSortKey(b) - getApptSortKey(a))
+
+  // Normalize status strings to a canonical form used in UI/logic (use function declaration for hoisting)
+  function normalizeStatus(s?: string) {
+    const u = String(s || "").toUpperCase().replace(/\s+/g, "-").replace(/_/g, "-")
+    if (u === "CHECKED-IN") return "CHECKED-IN"
+    if (u === "COMPLETED") return "COMPLETED"
+    if (u === "NO-SHOW") return "NO_SHOW"
+    return u
+  }
 
   // Update Status
   const updateApptStatus = async (apptId: String, status: String) => {
@@ -810,14 +831,77 @@ export default function StaffDashboard() {
   // Global WebSocket subscription for slot/appointment changes
   useEffect(() => {
     connectSocket()
-    const { unsubscribe } = subscribeToSlots((update: any) => {
-      if (!update) return
-      fetchAppointments()
-      fetchCompletedAppointments()
+    const statusSub = subscribeToAppointmentStatus((update: any) => {
+      // Handle appointment status events without full refetch when possible
+      try {
+        const apptId: string | undefined = update?.appointmentId || update?.appointment_id || update?.id
+        const rawStatus: string | undefined = update?.status
+        const updateClinicId: string | undefined = update?.clinicId || update?.clinic_id
+        if (!apptId || !rawStatus) return
+
+        // Ignore events from other clinics when clinic context is known
+        if (staffClinicId && updateClinicId && updateClinicId !== staffClinicId) return
+
+        const status = normalizeStatus(rawStatus)
+
+        // On CHECKED-IN, just update the item in-memory for a snappier nurse UI
+        if (status === "CHECKED-IN") {
+          const exists = appointments.some(a => a.appointment_id === apptId)
+          if (exists) {
+            setAppointments(prev => prev.map(a => (a.appointment_id === apptId ? { ...a, status: "CHECKED-IN" } : a)))
+            return
+          }
+          // If we don't have it locally (rare), fall back to a single refetch
+          fetchAppointments()
+          return
+        }
+
+        // For terminal states (COMPLETED/NO_SHOW), keep refetch to ensure both lists are consistent
+        if (status === "COMPLETED" || status === "NO_SHOW") {
+          fetchAppointments()
+          fetchCompletedAppointments()
+          return
+        }
+
+        // Unknown status: default to safe refetch
+        fetchAppointments()
+        fetchCompletedAppointments()
+      } catch {
+        fetchAppointments()
+        fetchCompletedAppointments()
+      }
     })
 
+    // Listen for treatment note updates to refresh or patch completed items in receptionist view
+    const notesSub = subscribeToTreatmentNotes((payload: any) => {
+      try {
+        const apptId: string | undefined = payload?.appointmentId || payload?.appointment_id
+        if (!apptId) return
+
+        // If receptionist has this appointment in completed list, patch note; else fetch once
+        const idx = completedAppointments.findIndex(a => a.appointment_id === apptId)
+        if (idx >= 0) {
+          const latest = {
+            id: payload.noteId,
+            notes: payload.notes,
+            noteType: payload.noteType || 'TREATMENT_SUMMARY',
+            createdAt: payload.createdAt || payload.updatedAt || new Date().toISOString(),
+            createdByName: payload.createdByName,
+          }
+          setCompletedAppointments(prev => prev.map((a, i) => i === idx ? { ...a, treatmentNote: latest } : a))
+        } else {
+          // Fallback: refresh completed list once
+          fetchCompletedAppointments()
+        }
+      } catch {
+        fetchCompletedAppointments()
+      }
+    })
+
+    // Ensure cleanup doesn't throw if subs are not available
     return () => {
-      unsubscribe()
+      try { statusSub.unsubscribe() } catch {}
+      try { notesSub && notesSub.unsubscribe && notesSub.unsubscribe() } catch {}
       // keep socket globally if other pages reuse it
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -861,6 +945,25 @@ export default function StaffDashboard() {
     const ampm = hours >= 12 ? "PM" : "AM"
     hours = hours % 12 || 12
     return `${String(hours).padStart(2, "0")}:${minutes} ${ampm}`
+  }
+
+  // Compute a numeric sort key for an appointment using booking_date + start_time
+  function getApptSortKey(appt: Appointment): number {
+    const iso = toIsoDate(appt.booking_date)
+    let hh = 0, mm = 0
+    if (Array.isArray(appt.start_time)) {
+      const [h, m] = appt.start_time as number[]
+      hh = Number(h) || 0
+      mm = Number(m) || 0
+    } else if (typeof appt.start_time === "string" && appt.start_time) {
+      const [h, m] = appt.start_time.substring(0,5).split(":")
+      hh = Number(h) || 0
+      mm = Number(m) || 0
+    }
+    // Build Date using local time
+    const [y, mo, d] = iso.split("-").map(n => Number(n))
+    const dt = new Date(y, (mo || 1) - 1, d || 1, hh, mm, 0, 0)
+    return dt.getTime()
   }
 
   return (


### PR DESCRIPTION
## Summary by Sourcery

Integrate websocket-based real-time updates across staff dashboards by broadcasting status and treatment note events from the backend and handling them on the frontend with normalized statuses, filtered views, and sorted appointment lists.

New Features:
- Enable real-time frontend subscriptions for appointment status and treatment note updates via websockets
- Broadcast appointment status and treatment note events from backend services to relevant websocket topics

Enhancements:
- Normalize status strings in the UI and restrict upcoming appointments to scheduled and checked-in
- Sort upcoming appointments ascending by date/time and completed appointments descending
- Patch in-memory appointment list for CHECKED-IN events to reduce full data refetch
- Add helper functions in socket client library for subscribing to appointment status and treatment notes