### PR TITLE
fix websocket reschedule issue

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -33,9 +33,9 @@ function App() {
         <Route
           path="/dashboard"
           element={
-            <ProtectedRoute>
+            <RoleProtectedRoute role={["ROLE_PATIENT"]}>
               <PatientDashboard />
-            </ProtectedRoute>
+            </RoleProtectedRoute>
           }
         />
         <Route


### PR DESCRIPTION
## Summary by Sourcery

Ensure rescheduled appointments continue to appear in the Upcoming tab and tighten access control for the patient dashboard

Bug Fixes:
- Treat appointments with status 'RESCHEDULED' as 'SCHEDULED' in the Staff Dashboard so they remain visible after rescheduling

Enhancements:
- Replace ProtectedRoute with RoleProtectedRoute on the patient dashboard route to enforce patient role access