### PR TITLE
feat(notifications): apply email template for N3_AWAY & NOW_SERVING

### DIFF
--- a/backend/src/main/java/com/is442/backend/service/NotificationEmailConsumer.java
+++ b/backend/src/main/java/com/is442/backend/service/NotificationEmailConsumer.java
@@ -1,14 +1,16 @@
 package com.is442.backend.service;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.is442.backend.dto.NotificationEvent;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.stereotype.Service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.is442.backend.dto.NotificationEvent;
 
 @Service
 @ConditionalOnProperty(name = "kafka.enabled", havingValue = "true")
@@ -16,9 +18,14 @@ public class NotificationEmailConsumer {
 
     private final JavaMailSender mailSender;
     private final ObjectMapper om = new ObjectMapper();
+    private final String fromAddress;
 
-    public NotificationEmailConsumer(JavaMailSender mailSender) {
+    public NotificationEmailConsumer(
+            JavaMailSender mailSender,
+            @Value("${app.mail.from:noreply@clinic.local}") String fromAddress
+    ) {
         this.mailSender = mailSender;
+        this.fromAddress = fromAddress;
     }
 
     @KafkaListener(
@@ -36,31 +43,37 @@ public class NotificationEmailConsumer {
                 return;
             }
 
-            // Payload is JSON string with subject, body, and patient.{email}
+            // Payload is JSON string (subject/body still produced, but we
+            // now build a richer template body from Appendix A)
             JsonNode payload = om.readTree(evt.payload());
-            String subject = payload.path("subject").asText("(no subject)");
-            String body    = payload.path("body").asText("");
-            String to      = payload.path("patient").path("email").asText("");
+            JsonNode patientNode = payload.path("patient");
+
+            String to = patientNode.path("email").asText("");
 
             if (to == null || to.isBlank()) {
-                System.out.printf("[NotificationEmailConsumer] Skipping: empty email for appt %s%n", evt.appointmentId());
+                System.out.printf(
+                        "[NotificationEmailConsumer] Skipping EMAIL: empty email for appt %s%n",
+                        evt.appointmentId()
+                );
                 return;
             }
 
             SimpleMailMessage msg = new SimpleMailMessage();
             msg.setTo(to);
-            msg.setFrom("noreply@clinic.local"); // dev sender
-            msg.setSubject(subject);
-            msg.setText(body + String.format(
-                    "%n%nClinic: %s%nDoctor: %s%nQueue #: %s%nAppointment ID: %s",
-                    safe(payload, "clinicId"),
-                    safe(payload, "doctorName"),
-                    payload.path("patient").path("queue_number").asText(""),
-                    evt.appointmentId()
-            ));
+            msg.setFrom(fromAddress);
+
+            // Fixed subject per Appendix A
+            msg.setSubject("Appointment & Queue Update – SingHealth Clinic");
+
+            // Rich body based on event type + payload
+            msg.setText(buildTemplateBody(evt, payload));
 
             mailSender.send(msg);
-            System.out.printf("[NotificationEmailConsumer] Sent EMAIL '%s' → %s%n", evt.type(), to);
+            System.out.printf(
+                    "[NotificationEmailConsumer] Sent EMAIL '%s' → %s%n",
+                    evt.type(),
+                    to
+            );
 
         } catch (Exception e) {
             System.err.println("[NotificationEmailConsumer] Failed to process: " + e.getMessage());
@@ -68,8 +81,100 @@ public class NotificationEmailConsumer {
         }
     }
 
+    /**
+     * Build Appendix A style email:
+     *
+     * Subject: Appointment & Queue Update – SingHealth Clinic
+     * Dear [Patient Name],
+     * Thank you for booking your appointment at [Clinic Name].
+     *  • Doctor: [Doctor Name]
+     *  • Date & Time: [Appointment Date & Time]
+     *  • Queue Number: [Queue Number]
+     * ...
+     * Queue Update Notifications:
+     *  • "You are currently 3 patients away..."  (N3_AWAY)
+     *  • "It’s your turn. Kindly enter..."      (NOW_SERVING)
+     */
+    private String buildTemplateBody(NotificationEvent evt, JsonNode payload) {
+        JsonNode patientNode = payload.path("patient");
+
+        String patientName = safe(patientNode, "name");
+        if (patientName.isBlank()) {
+            patientName = "Patient";
+        }
+
+        // Try friendly clinic name first, then clinicId, then default
+        String clinicName = safe(payload, "clinicName");
+        if (clinicName.isBlank()) {
+            clinicName = safe(payload, "clinicId");
+        }
+        if (clinicName.isBlank()) {
+            clinicName = "SingHealth Clinic";
+        }
+
+        String doctorName = safe(payload, "doctorName");
+        if (doctorName.isBlank()) {
+            doctorName = "Doctor";
+        }
+
+        String queueNumber = safe(patientNode, "queue_number");
+        if (queueNumber.isBlank()) {
+            queueNumber = "-";
+        }
+
+        // Currently not in payload; phrase safely
+        String appointmentDateTime = safe(payload, "appointmentDateTime");
+        if (appointmentDateTime.isBlank()) {
+            appointmentDateTime = "As per your appointment booking";
+        }
+
+        // Choose the one-line queue update message based on event type
+        String queueUpdateLine;
+        String type = evt.type(); // e.g. "N3_AWAY" or "NOW_SERVING"
+
+        if ("N3_AWAY".equalsIgnoreCase(type)) {
+            queueUpdateLine =
+                    "You are currently 3 patients away. Please proceed closer to the consultation room.";
+        } else if ("NOW_SERVING".equalsIgnoreCase(type)) {
+            // If you later add room number, inject it here.
+            queueUpdateLine =
+                    "It’s your turn. Kindly enter the consultation room.";
+        } else {
+            // Fallback – reuse original body if present, otherwise generic line
+            String body = safe(payload, "body");
+            queueUpdateLine = body.isBlank()
+                    ? "Your queue status has been updated."
+                    : body;
+        }
+
+        // Final body (Appendix A style)
+        return String.format(
+                "Dear %s,%n%n" +
+                "Thank you for booking your appointment at %s.%n%n" +
+                "• Doctor: %s%n" +
+                "• Date & Time: %s%n" +
+                "• Queue Number: %s%n%n" +
+                "We will notify you again when your turn is approaching. " +
+                "Please be present at the clinic when your queue number is called.%n%n" +
+                "Queue Update Notifications:%n" +
+                "• %s%n%n" +
+                "We look forward to serving you.%n%n" +
+                "Warm regards,%n" +
+                "SingHealth Clinic Team%n",
+                patientName,
+                clinicName,
+                doctorName,
+                appointmentDateTime,
+                queueNumber,
+                queueUpdateLine
+        );
+    }
+
     private String safe(JsonNode node, String field) {
+        if (node == null) {
+            return "";
+        }
         JsonNode n = node.path(field);
-        return n.isMissingNode() ? "" : n.asText("");
+        return n.isMissingNode() || n.isNull() ? "" : n.asText("");
     }
 }


### PR DESCRIPTION
## Summary by Sourcery

Apply a standardized email template for queue notifications by injecting a configurable sender address, setting a fixed subject, and constructing a detailed body with patient, appointment, and queue update information based on event type.

New Features:
- Make the sender address configurable via the app.mail.from property
- Use a fixed email subject and rich body template for appointment and queue update notifications
- Introduce a buildTemplateBody method to generate personalized email content per event type (N3_AWAY and NOW_SERVING)

Enhancements:
- Improve logging statements when sending and skipping emails
- Enhance safe() helper to handle null JSON nodes more robustly