### PR TITLE
fix: mock timings

### DIFF
--- a/backend/src/main/java/com/is442/backend/model/StaffReport.java
+++ b/backend/src/main/java/com/is442/backend/model/StaffReport.java
@@ -76,7 +76,8 @@ public class StaffReport {
     @PrePersist
     protected void onCreate() {
         // Store in Singapore timezone (GMT+8)
-        generatedAt = OffsetDateTime.now(ZoneOffset.of("+08:00"));
+        // generatedAt = OffsetDateTime.now(ZoneOffset.of("+08:00"));
+        generatedAt = OffsetDateTime.of(2025, 11, 13, 13, 0, 0, 0, ZoneOffset.of("+08:00")); // MOCK: Singapore time
     }
 
     // Getters and Setters

--- a/backend/src/main/java/com/is442/backend/service/TimeSlotService.java
+++ b/backend/src/main/java/com/is442/backend/service/TimeSlotService.java
@@ -154,7 +154,7 @@ public class TimeSlotService {
         // LocalDate today = LocalDate.now();
         LocalDate today = LocalDate.of(2025, 11, 13); // MOCK: fixed demo date
         // LocalTime currentTime = LocalTime.now();
-        LocalTime currentTime = LocalTime.of(13, 0, 0); // MOCK: fixed demo time
+        LocalTime currentTime = LocalTime.of(12, 0, 0); // MOCK: fixed demo time (12:00 PM to allow booking from 1:00 PM onwards)
         LocalDate end = today.plusWeeks(8);
         List<AvailableDateSlotsDto> result = new ArrayList<>();
 

--- a/frontend/src/pages/BookAppointment.tsx
+++ b/frontend/src/pages/BookAppointment.tsx
@@ -28,6 +28,11 @@ import { PageLayout } from "../components/page-layout";
 
 const clinicTypes = ["General Practice", "Specialist Clinic"];
 
+// MOCK time for testing - matches backend mock time
+// const REAL_NOW = new Date();
+const MOCK_NOW = new Date(2025, 10, 13, 12, 0, 0); // MOCK: 13 Nov 2025 12:00 PM local (matches backend mock time)
+const nowTime = () => MOCK_NOW;
+
 export default function AppointmentBooking() {
   const [selectedDoctors, setSelectedDoctors] = useState<string[]>([]);
   const [selectedClinicType, setSelectedClinicType] = useState<string>("");
@@ -308,7 +313,7 @@ export default function AppointmentBooking() {
         const data = await res.json();
         setAvailableDatesWithSlots(data);
 
-        const now = new Date();
+        const now = nowTime(); // Use mock time to match backend
         const currentMinutes = now.getHours() * 60 + now.getMinutes();
 
         function parseTimeToMinutes(timeStr: string): number {
@@ -394,8 +399,8 @@ export default function AppointmentBooking() {
     return matches;
   });
 
-  const today = new Date();
-  const maxDate = new Date();
+  const today = nowTime(); // Use mock time to match backend
+  const maxDate = new Date(today);
   maxDate.setDate(today.getDate() + 7 * 8); // up to 8 weeks ahead
 
   const selectedDaySlotsDetailed = availableDatesWithSlots.filter((d) => {
@@ -886,7 +891,7 @@ export default function AppointmentBooking() {
               ) : (
                 <Card className="p-4 bg-card">
                   {(() => {
-                    const now = new Date();
+                    const now = nowTime(); // Use mock time to match backend
                     const currentMinutes = now.getHours() * 60 + now.getMinutes();
 
                     function parseTimeToMinutes(timeStr: string): number {


### PR DESCRIPTION
## Summary by Sourcery

Mock all timing-related functions and constants in both the frontend appointment booking page and backend services to use fixed timestamps for consistent testing.

Enhancements:
- Define a mock time provider in the frontend and replace all new Date() calls with nowTime() returning a fixed demo timestamp.
- Stub backend timing by fixing generatedAt in StaffReport to a constant OffsetDateTime and using fixed LocalDate and LocalTime values in TimeSlotService.