### PR TITLE
change mock time back to realtime for submission

### DIFF
--- a/backend/src/main/java/com/is442/backend/model/Appointment.java
+++ b/backend/src/main/java/com/is442/backend/model/Appointment.java
@@ -70,16 +70,13 @@ public class Appointment {
 
     @PrePersist
     protected void onCreate() {
-        // createdAt = LocalDateTime.now();
-        // updatedAt = LocalDateTime.now();
-        createdAt = LocalDateTime.of(2025, 11, 13, 13, 0, 0); // MOCK
-        updatedAt = createdAt; // MOCK
+        createdAt = LocalDateTime.now();
+        updatedAt = LocalDateTime.now();
     }
 
     @PreUpdate
     protected void onUpdate() {
-        // updatedAt = LocalDateTime.now();
-        updatedAt = LocalDateTime.of(2025, 11, 13, 13, 0, 0); // MOCK
+        updatedAt = LocalDateTime.now();
     }
 
     public UUID getAppointmentId() {

--- a/backend/src/main/java/com/is442/backend/model/StaffReport.java
+++ b/backend/src/main/java/com/is442/backend/model/StaffReport.java
@@ -76,8 +76,7 @@ public class StaffReport {
     @PrePersist
     protected void onCreate() {
         // Store in Singapore timezone (GMT+8)
-        // generatedAt = OffsetDateTime.now(ZoneOffset.of("+08:00"));
-        generatedAt = OffsetDateTime.of(2025, 11, 13, 13, 0, 0, 0, ZoneOffset.of("+08:00")); // MOCK: Singapore time
+        generatedAt = OffsetDateTime.now(ZoneOffset.of("+08:00"));
     }
 
     // Getters and Setters

--- a/backend/src/main/java/com/is442/backend/model/TreatmentNote.java
+++ b/backend/src/main/java/com/is442/backend/model/TreatmentNote.java
@@ -42,16 +42,13 @@ public class TreatmentNote {
     
     @PrePersist
     protected void onCreate() {
-        // createdAt = OffsetDateTime.now();
-        // updatedAt = OffsetDateTime.now();
-        createdAt = OffsetDateTime.of(2025, 11, 13, 13, 0, 0, 0, java.time.ZoneOffset.UTC); // MOCK
-        updatedAt = createdAt; // MOCK
+        createdAt = OffsetDateTime.now();
+        updatedAt = OffsetDateTime.now();
     }
     
     @PreUpdate
     protected void onUpdate() {
-        // updatedAt = OffsetDateTime.now();
-        updatedAt = OffsetDateTime.of(2025, 11, 13, 13, 0, 0, 0, java.time.ZoneOffset.UTC); // MOCK
+        updatedAt = OffsetDateTime.now();
     }
     
     // Getters and Setters

--- a/backend/src/main/java/com/is442/backend/service/AppointmentService.java
+++ b/backend/src/main/java/com/is442/backend/service/AppointmentService.java
@@ -60,8 +60,7 @@ public class AppointmentService {
      */
     private void validateAdvanceNotice(Appointment appointment) {
         LocalDateTime appointmentDateTime = LocalDateTime.of(appointment.getBookingDate(), appointment.getStartTime());
-        // LocalDateTime now = LocalDateTime.now();
-        LocalDateTime now = LocalDateTime.of(2025, 11, 13, 13, 0, 0); // MOCK: fixed demo time (comment out to use real now)
+        LocalDateTime now = LocalDateTime.now();
         LocalDateTime minimumTime = now.plusHours(24);
 
         if (appointmentDateTime.isBefore(minimumTime)) {
@@ -279,8 +278,7 @@ public class AppointmentService {
 
     @Transactional(readOnly = true)
     public List<AppointmentResponse> getUpcomingAppointments(String patientId) {
-        // LocalDate today = LocalDate.now();
-        LocalDate today = LocalDate.of(2025, 11, 13); // MOCK: fixed demo date (comment out to use real today)
+        LocalDate today = LocalDate.now();
         return appointmentRepository.findUpcomingAppointmentsByPatient(patientId, today).stream()
                 .map(appointment -> {
                     Optional<Doctor> docOpt = doctorRepository.findByDoctorId(appointment.getDoctorId());
@@ -311,8 +309,7 @@ public class AppointmentService {
 
     @Transactional(readOnly = true)
     public List<AppointmentResponse> getUpcomingAppointments() {
-        // LocalDate today = LocalDate.now();
-        LocalDate today = LocalDate.of(2025, 11, 13); // MOCK: fixed demo date (comment out to use real today)
+        LocalDate today = LocalDate.now();
         return appointmentRepository.findUpcomingAppointments(today).stream()
                 .map(appointment -> {
                     Optional<Doctor> docOpt = doctorRepository.findByDoctorId(appointment.getDoctorId());
@@ -622,16 +619,12 @@ public class AppointmentService {
             return;
         }
 
-    // LocalDate today = LocalDate.now();
-    LocalDate today = LocalDate.of(2025, 11, 13); // MOCK: fixed demo date
-    // LocalTime now = LocalTime.now();
-    LocalTime now = LocalTime.of(13, 0, 0); // MOCK: fixed demo time
+    LocalDate today = LocalDate.now();
+    LocalTime now = LocalTime.now();
     // end_time can be null for walk-in appointments but has some issues, we put an
     // estimated end time first
-    // LocalTime endTime = LocalTime.now().plusHours(1);
-    LocalTime endTime = now.plusHours(1); // MOCK: derive from fixed demo time
-    // LocalDateTime createdAt = LocalDateTime.now();
-    LocalDateTime createdAt = LocalDateTime.of(2025, 11, 13, 13, 0, 0); // MOCK: fixed demo timestamp
+    LocalTime endTime = LocalTime.now().plusHours(1);
+    LocalDateTime createdAt = LocalDateTime.now();
 
         // Use native SQL INSERT to bypass Hibernate's entity management
         // This allows us to manually set the UUID without conflicts with

--- a/backend/src/main/java/com/is442/backend/service/RedisQueueService.java
+++ b/backend/src/main/java/com/is442/backend/service/RedisQueueService.java
@@ -16,6 +16,7 @@ import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.core.script.DefaultRedisScript;
 import org.springframework.stereotype.Service;
 
+import java.time.Instant;
 import java.util.concurrent.CompletableFuture;
 import java.util.*;
 
@@ -154,8 +155,7 @@ public class RedisQueueService {
         meta.put("phone", user.getPhone());
         meta.put("email", user.getEmail());
         meta.put("name", user.getFirstName() + " " + user.getLastName());
-    // meta.put("createdAt", Instant.now().toString());
-    meta.put("createdAt", "2025-11-13T13:00:00Z"); // MOCK: fixed demo instant
+    meta.put("createdAt", Instant.now().toString());
 
         // 3) Validate and fetch doctor information if provided
         if (doctorId != null && !doctorId.trim().isEmpty()) {

--- a/backend/src/main/java/com/is442/backend/service/TimeSlotService.java
+++ b/backend/src/main/java/com/is442/backend/service/TimeSlotService.java
@@ -151,10 +151,8 @@ public class TimeSlotService {
     }
 
     public List<AvailableDateSlotsDto> getAvailableDatesWithSlots(String speciality, String clinicId, List<String> doctorIds) {
-        // LocalDate today = LocalDate.now();
-        LocalDate today = LocalDate.of(2025, 11, 13); // MOCK: fixed demo date
-        // LocalTime currentTime = LocalTime.now();
-        LocalTime currentTime = LocalTime.of(12, 0, 0); // MOCK: fixed demo time (12:00 PM to allow booking from 1:00 PM onwards)
+        LocalDate today = LocalDate.now();
+        LocalTime currentTime = LocalTime.now();
         LocalDate end = today.plusWeeks(8);
         List<AvailableDateSlotsDto> result = new ArrayList<>();
 

--- a/frontend/src/pages/BookAppointment.tsx
+++ b/frontend/src/pages/BookAppointment.tsx
@@ -28,10 +28,7 @@ import { PageLayout } from "../components/page-layout";
 
 const clinicTypes = ["General Practice", "Specialist Clinic"];
 
-// MOCK time for testing - matches backend mock time
-// const REAL_NOW = new Date();
-const MOCK_NOW = new Date(2025, 10, 13, 12, 0, 0); // MOCK: 13 Nov 2025 12:00 PM local (matches backend mock time)
-const nowTime = () => MOCK_NOW;
+const nowTime = () => new Date();
 
 export default function AppointmentBooking() {
   const [selectedDoctors, setSelectedDoctors] = useState<string[]>([]);

--- a/frontend/src/pages/PatientDashboard.tsx
+++ b/frontend/src/pages/PatientDashboard.tsx
@@ -99,9 +99,7 @@ export default function PatientDashboard() {
         currentNumber: null,
     })
 
-    // Mock current time for demo
-    // const currentNow = () => new Date() // real current time
-    const currentNow = () => new Date(2025, 10, 13, 13, 0, 0) // MOCK: 13 Nov 2025 1:00 PM local
+    const currentNow = () => new Date()
 
     // --- normalization helpers ---
     const toDateString = (booking_date: any): string => {
@@ -245,16 +243,14 @@ export default function PatientDashboard() {
             clinic_name: clinic_name ?? "",
             clinic_type: event.type ?? event.clinic_type ?? "",
             clinic_address: "",
-            // created_at: event.createdAt ?? event.created_at ?? new Date().toISOString(),
-            created_at: event.createdAt ?? event.created_at ?? currentNow().toISOString(), // MOCK
+            created_at: event.createdAt ?? event.created_at ?? currentNow().toISOString(),
             doctor_id,
             doctor_name: doctor_name ?? "",
             end_time: end_time ?? "",
             patient_id: evtPatientId,
             start_time: start_time ?? "",
             status,
-            // updated_at: event.updatedAt ?? event.updated_at ?? new Date().toISOString(),
-            updated_at: event.updatedAt ?? event.updated_at ?? currentNow().toISOString(), // MOCK
+            updated_at: event.updatedAt ?? event.updated_at ?? currentNow().toISOString(),
         }
 
         return { appointment, needsFetch }
@@ -292,16 +288,14 @@ export default function PatientDashboard() {
                 clinic_name: data.clinicName ?? data.clinic_name ?? "",
                 clinic_type: data.clinicType ?? data.clinic_type ?? "",
                 clinic_address: data.clinicAddress ?? "",
-                // created_at: data.createdAt ?? data.created_at ?? new Date().toISOString(),
-                created_at: data.createdAt ?? data.created_at ?? currentNow().toISOString(), // MOCK
+                created_at: data.createdAt ?? data.created_at ?? currentNow().toISOString(),
                 doctor_id: data.doctorId ?? data.doctor_id ?? "",
                 doctor_name: data.doctorName ?? data.doctor_name ?? "",
                 end_time: data.endTime ?? data.end_time ?? "",
                 patient_id: data.patientId ?? data.patient_id ?? "",
                 start_time: data.startTime ?? data.start_time ?? "",
                 status: (data.status ?? "").toUpperCase(),
-                // updated_at: data.updatedAt ?? data.updated_at ?? new Date().toISOString(),
-                updated_at: data.updatedAt ?? data.updated_at ?? currentNow().toISOString(), // MOCK
+                updated_at: data.updatedAt ?? data.updated_at ?? currentNow().toISOString(),
             }
         } catch (e) {
             console.warn("Failed to fetch appointment by id:", id, e)

--- a/frontend/src/pages/StaffDashboard.tsx
+++ b/frontend/src/pages/StaffDashboard.tsx
@@ -147,9 +147,7 @@ export default function StaffDashboard() {
 
   const navigate = useNavigate()
 
-  // const REAL_NOW = new Date();
-  const MOCK_NOW = new Date(2025, 10, 13, 13, 0, 0) // MOCK: 13 Nov 2025 1:00 PM local (comment this and use REAL_NOW to revert)
-  const nowTime = () => MOCK_NOW
+  const nowTime = () => new Date()
 
   const doctorCache = useRef<Map<string, string>>(new Map())
   const clinicCache = useRef<Map<string, string>>(new Map())
@@ -1390,10 +1388,8 @@ export default function StaffDashboard() {
             end_time: endTime,
             patient_name: patientName, 
             status: displayStatus,
-            // created_at: event.createdAt ?? event.created_at ?? new Date().toISOString(),
-            // updated_at: new Date().toISOString()
-            created_at: event.createdAt ?? event.created_at ?? nowTime().toISOString(), // MOCK
-            updated_at: nowTime().toISOString() // MOCK
+            created_at: event.createdAt ?? event.created_at ?? nowTime().toISOString(),
+            updated_at: nowTime().toISOString()
           }
           return [newAppt, ...prev]
         })


### PR DESCRIPTION
## Summary by Sourcery

Revert all mock/demo timestamps to use the system’s real current time across backend services, entity models, and frontend components, ensuring time-sensitive logic and timestamps reflect actual runtime.

Enhancements:
- Replace hard-coded demo dates and times with LocalDate.now(), LocalTime.now(), LocalDateTime.now(), OffsetDateTime.now(), and Instant.now() in backend service and model classes
- Restore real current Date usage in frontend PatientDashboard, StaffDashboard, and BookAppointment components for time display and timestamp generation